### PR TITLE
PyBridge - v1.4

### DIFF
--- a/ErrorReport/ErrorList.py
+++ b/ErrorReport/ErrorList.py
@@ -7,17 +7,17 @@ class Raise():
          raise Exception(f'\n\n>> You cannot run the application because it requires Python {TargetVersion} or later. [Current Version: {CurrentVersion}]')
 
       def MinorVersion(self, CurrentVersion, TargetVersion, TargetMinor):
-         print("="*40)
+         print("=" * 80)
          print(">> PYBRIDGE <<")
-         print("="*40)
+         print("=" * 80)
          print(">> WARNING <<")
-         print("="*40)
+         print("=" * 80)
          print(f'>> Your appication targets a version of Python older than the version currently\ninstalled. You may get errors during the process')
-         print("="*40)
+         print("=" * 80)
          print(f'- Current Version: {CurrentVersion}')
          print(f'- Target Version: {TargetVersion}')
          print(f'>> You can change `SystemRequirements.py` on `ErrorReport` Module')
-         print("="*40)
+         print("=" * 80)
          print()
 
       def BuildVersion(self, CurrentVersion, TargetVersion, BuildVer):
@@ -36,30 +36,30 @@ def InputFormat():
    print("\n\n\n>> Your input is not valid: Check your input and try again\n\n")
 
 def InvalidOption():
-   print("="*80)
+   print("=" * 80)
    print(">> Invalid Option!")
-   print("="*80)
+   print("=" * 80)
    print(f'>> You typed an invalid option.\n>> Running the program again!')
-   print("="*80)
+   print("=" * 80)
 
 def ProjectsLoadFail():
-   print("="*80)
+   print("=" * 80)
    print(f'>> ERROR: Couldn`t load projects...')
-   print("="*80)
+   print("=" * 80)
 
 def BackupFail():
-   print("="*80)
+   print("=" * 80)
    print(">> BACKUP CREATION FAILED!")
-   print("="*80)
+   print("=" * 80)
    print("[=]" * 20)
    print(f'>> PyBridge could not create backup for your projects folder')
    print(f'>> Try again later.')
    print("[=]" * 20)
 
 def CompressBackupFail():
-   print("="*80)
+   print("=" * 80)
    print(">> COMPRESSED FILE CREATION FAILED!")
-   print("="*80)
+   print("=" * 80)
    print("[=]" * 20)
    print(f'>> PyBridge could not create a compressed file from your backup')
    print(f'>> Try again later.')

--- a/ErrorReport/SystemRequirements.py
+++ b/ErrorReport/SystemRequirements.py
@@ -4,11 +4,11 @@
 import sys
 from ErrorReport import ErrorList
 
-## Change "Require" to "False" to skip system check
-Require = True
-## Change "Require" to "True" to allow system check
+## Change "REQUIRE" to "False" to skip system check
+REQUIRE = True
+## Change "REQUIRE" to "True" to allow system check
 
-if Require == True:
+if REQUIRE == True:
    ## Target System
    TargetMajor = 3
    TargetMinor = 9
@@ -22,13 +22,44 @@ if Require == True:
    BuildVersion = sys.version_info[2]
    CurrentVersion = f'{MajorVersion}.{MinorVersion}.{BuildVersion}'
    ## Current System
-   
+
    ## Uncomment to see information about your system
    ## print(f'>> My system current version: Python {CurrentVersion}')
    ## print(f'>> Required version to run: Python {TargetVersion}')
 
-   if TargetVersion > CurrentVersion:
-      ErrorList.Raise().Requirements().MajorVersion(CurrentVersion, TargetVersion, TargetMajor)
-   elif TargetVersion < CurrentVersion:
-      ErrorList.Raise().Requirements().MinorVersion(CurrentVersion, TargetVersion, TargetMinor)
+   def CheckMajorVersion():
+      ## Note: if this key is set to False, the system won't run even if meets requirements
+      AllowKey = True
+      ## Note: if this key is set to False, the system won't run even if meets requirements
+      
+      if MajorVersion < TargetMajor:
+         AllowKey = False
+      else:
+         if MinorVersion < TargetMinor:
+             AllowKey = False
+         else:
+             if BuildVersion < TargetBuild:
+                 AllowKey = False
+                 
+      if AllowKey == False:
+         ErrorList.Raise().Requirements().MajorVersion(CurrentVersion, TargetVersion, TargetMajor)
 
+   def CheckMinorVersion():
+      ## Note: if this key is set to True, the system will warn evertime it runs
+      ShowWarn = False
+      ## Note: if this key is set to True, the system will warn evertime it runs
+      
+      if MajorVersion > TargetMajor:
+         ShowWarn = True
+      else:
+         if MinorVersion > TargetMinor:
+             ShowWarn = True
+         else:
+             if BuildVersion > TargetBuild:
+                 ShowWarn = True
+                 
+      if ShowWarn == True:
+         ErrorList.Raise().Requirements().MinorVersion(CurrentVersion, TargetVersion, TargetMinor)
+
+   CheckMajorVersion()
+   CheckMinorVersion()

--- a/Linux/SplashScreen.py
+++ b/Linux/SplashScreen.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 CurrentYear = datetime.now().year
 SoftwareName = "PyBridge"
-Version = "1.3.1"
+Version = "1.4"
 CopyrightName = "Heitor Bisneto"
 
 Now = datetime.now()

--- a/Mac/SplashScreen.py
+++ b/Mac/SplashScreen.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 CurrentYear = datetime.now().year
 SoftwareName = "PyBridge"
-Version = "1.3.1"
+Version = "1.4"
 CopyrightName = "Heitor Bisneto"
 
 Now = datetime.now()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PyBridge
-###### Last repository update: 23/03/2022
+###### Last repository update: 02/04/2022
 
 With PyBridge it is possible to run Python scripts by bridging the code implemented in the project created with other platforms.
 
@@ -176,7 +176,7 @@ The following libraries were used to implement the tool:
     - Read more about the ```os``` library at [os — Miscellaneous operating system interfaces](https://docs.python.org/3/library/os.html)
 
 * **pathlib:** This module offers classes representing filesystem paths with semantics appropriate for different operating systems. Path classes are divided between pure paths, which provide purely computational operations without I/O, and concrete paths, which inherit from pure paths but also provide I/O operations.
-    - Read more about the ```pathlib ``` library at [pathlib — Object-oriented filesystem paths](https://docs.python.org/3/library/pathlib.html)
+    - Read more about the ```pathlib``` library at [pathlib — Object-oriented filesystem paths](https://docs.python.org/3/library/pathlib.html)
 
 * **shutil:** The shutil module provides several high-level operations on files and file collections. In particular, functions are provided that support copying and removing files. For operations on individual files, see also the **os** module.
     - Read more about the ```shutil``` library at [shutil — High-level file operations](https://docs.python.org/3/library/shutil.html)

--- a/Windows/SplashScreen.py
+++ b/Windows/SplashScreen.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 CurrentYear = datetime.now().year
 SoftwareName = "PyBridge"
-Version = "1.3.1"
+Version = "1.4"
 CopyrightName = "Heitor Bisneto"
 
 Now = datetime.now()


### PR DESCRIPTION
This update targets the libraries `ErrorList.py` and `SystemRequirements.py`
- Minor changes in `ErrorList.py`
- Fixed a bug in `SystemRequirements.py` that raise a Runtime exception on Python 3.10 when system targets Python 3.9 to run.
- Updated README file.

With PyBridge 1.4, Python 3.10 is finally supported.